### PR TITLE
Legg til daglige jobber for automatisk DVH-import

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,6 +100,47 @@ jobs:
           VARS: .nais/${{ matrix.cluster }}-gcp.yaml
           VAR: JOBB=prosesserPlanlagteHendelser,JOBB_NAVN_NAISVENNLIG=prosesser-planlagte-hendelser
 
+  deploy-sjekk-publiseringsdato:
+    needs: build
+    strategy:
+      matrix:
+        cluster: [dev, prod]
+    permissions:
+      id-token: write
+    name: Deployer daglig publiseringsdato-sjekk til ${{ matrix.cluster }}-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Deploy application to ${{ matrix.cluster }}-gcp
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          CLUSTER: ${{ matrix.cluster }}-gcp
+          RESOURCE: .nais/nais_daglig.yaml
+          VARS: .nais/${{ matrix.cluster }}-gcp.yaml
+          VAR: JOBB=sjekkPubliseringsdatoOgImporter,JOBB_NAVN_NAISVENNLIG=sjekk-publiseringsdato,SCHEDULE=0 6 * * *
+
+
+  deploy-publiseringsdato-dvh-import:
+    needs: build
+    strategy:
+      matrix:
+        cluster: [dev, prod]
+    permissions:
+      id-token: write
+    name: Deployer daglig publiseringsdato-import til ${{ matrix.cluster }}-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Deploy application to ${{ matrix.cluster }}-gcp
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+          CLUSTER: ${{ matrix.cluster }}-gcp
+          RESOURCE: .nais/nais_daglig.yaml
+          VARS: .nais/${{ matrix.cluster }}-gcp.yaml
+          VAR: JOBB=publiseringsdatoDvhImport,JOBB_NAVN_NAISVENNLIG=publiseringsdato-dvh-import,SCHEDULE=0 19 * * *
+
 
   trivy-scan:
     name: Scanner docker image med Trivy

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,7 +104,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        cluster: [dev, prod]
+        cluster: [dev]
     permissions:
       id-token: write
     name: Deployer daglig publiseringsdato-sjekk til ${{ matrix.cluster }}-gcp
@@ -125,7 +125,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        cluster: [dev, prod]
+        cluster: [dev]
     permissions:
       id-token: write
     name: Deployer daglig publiseringsdato-import til ${{ matrix.cluster }}-gcp

--- a/.github/workflows/manuell-deploy.yaml
+++ b/.github/workflows/manuell-deploy.yaml
@@ -38,6 +38,7 @@ on:
           - 'virksomhetSykefraværsstatistikkDvhImport'
           - 'virksomhetMetadataSykefraværsstatistikkDvhImport'
           - 'publiseringsdatoDvhImport'
+          - 'sjekkPubliseringsdatoOgImporter'
           - 'kalkulerResulterendeStatusForHendelser'
           - 'prosesserPlanlagtHendelse'
           - 'prosesserPlanlagteHendelser'

--- a/.nais/nais_daglig.yaml
+++ b/.nais/nais_daglig.yaml
@@ -1,0 +1,20 @@
+apiVersion: nais.io/v1
+kind: Naisjob
+metadata:
+  labels:
+    team: pia
+  name: pia-jobbsender-{{ JOBB_NAVN_NAISVENNLIG }}
+  namespace: pia
+spec:
+  image: {{ image }}
+  schedule: "{{ SCHEDULE }}"
+  timeZone: "UTC"
+  kafka:
+    pool: {{ kafkaPool }}
+  env:
+    - name: JOBB
+      value: {{ JOBB }}
+    - name: JOBBLYTTER_TOPIC
+      value: pia.jobblytter-v1
+    - name: KAFKA_CLIENT_ID
+      value: pia-jobbsender-daglig


### PR DESCRIPTION
## Legg til daglige jobber for automatisk DVH-import

Legger til to nye daglige jobber som trigger automatisk import av sykefraværsstatistikk i `pia-dvh-import`.

### Endringer

#### Ny template: `nais_daglig.yaml`
- Parametrisert NaisJob-template med `{{ SCHEDULE }}` — gjør at flere jobber kan gjenbruke samme template med ulike tidspunkt

#### Nye deploy-jobber i `build.yaml`

| Jobb | Schedule (UTC) | Norsk tid |
|---|---|---|
| `sjekkPubliseringsdatoOgImporter` | `0 6 * * *` | 08:00 CEST |
| `publiseringsdatoDvhImport` | `0 19 * * *` | 21:00 CEST |

#### Manuell deploy
- `sjekkPubliseringsdatoOgImporter` lagt til i dropdown for manuell kjøring

### Kontekst

Jobbene sender meldinger til `pia.jobblytter-v1` som konsumeres av `pia-dvh-import`. Selve logikken er implementert der (se navikt/pia-dvh-import#XX).

`pia-dvh-import` deployes med `DRY_RUN=true` — jobbene er trygge å deploye uten at Kafka-meldinger sendes downstream.